### PR TITLE
Feature/optimize hash

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NMEAParser"
 uuid = "e33883a1-8aa8-4e6e-a42d-0daf9e203b40"
 authors = ["Nicholas Shindler <nick@shindler.tech>"]
-version = "2.1.0"
+version = "2.1.1"
 
 [weakdeps]
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -41,9 +41,10 @@ macro do_parse(headers, header_str, items, system, valid)
     end
 end
 
-function hash_msg(message::AbstractString)
-    xor.(Vector{UInt8}(split(message, "\$")[2])...)
-end
+_char_xor(a::Char,b::Char) = xor(UInt8(a), UInt8(b))
+_char_xor(a::UInt8,b::Char) = xor(a, UInt8(b))
+_char_xor(a::Char,b::UInt8) = xor(UInt8(a), b)
+hash_msg(message::AbstractString)::UInt8 = foldl(_char_xor, chopprefix(message, "\$"))
 
 """
     get_system(mtype::SubString)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -160,16 +160,20 @@ end
 @testset "Bad data: parse_msg!" begin
     s = NMEAData()
     @test_throws BoundsError NMEAParser.parse_msg!(s, "")
-    @test_throws BoundsError NMEAParser.parse_msg!(
+    @test NMEAParser.parse_msg!(
         s,
-        "GPGSA,A,3,01,02,03,04,05,06,07,08,09,10,11,12,1.0,1.0,1.0*30",
-    )
+        raw"$NOTAREALHEADER,A,3,01,02,03,04,05,06,07,08,09,10,11,12,1.0,1.0,1.0*30",
+    ) === Nothing
 end
 
 @testset "hash strings" begin
     msg = raw"$GPRMC,154922.720,A,5209.731,N,00600.238,E,001.9,059.8,040123,000.0,W"
     checksum = 0x7a
     @test NMEAParser.hash_msg(msg) === checksum
+
+    @test NMEAParser._char_xor('s', '#') === NMEAParser._char_xor('#', 's')
+    @test NMEAParser._char_xor('s', 0x23) === NMEAParser._char_xor(0x23, 's')
+    @test NMEAParser._char_xor('s', '#') === NMEAParser._char_xor('s', 0x23)
 end
 
 @testset "supported nmea" begin


### PR DESCRIPTION
# Optimize the hash function for checksum validation

added an internal `_char_xor` function that handles Char to UInt8 conversion and allows calling `foldl` directly on the string.

This gives significant performance improvement:

#### old version
```julia_repl
julia> @benchmark NMEAParser.hash_msg(message)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  268.443 μs …  5.542 ms  ┊ GC (min … max): 0.00% … 91.39%
 Time  (median):     284.955 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   291.835 μs ± 75.036 μs  ┊ GC (mean ± σ):  0.33% ±  1.30%

  ▅▂▁▁▂█▅▄▄▄▆▆▅▄▄▄▄▄▃▃▄▃▃▃▃▂▂▂▂▁▁▁▁▁▁▁  ▁                      ▂
  ███████████████████████████████████████████▇█▇▇█▇▇▆▇▇▆▄▆▆▆▆▆ █
  268 μs        Histogram: log(frequency) by time       359 μs <

 Memory estimate: 12.47 KiB, allocs estimate: 281.
 
julia> @benchmark NMEAParser.nmea_parse(message)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  276.243 μs …   8.496 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     286.042 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   294.879 μs ± 125.454 μs  ┊ GC (mean ± σ):  0.48% ± 1.60%

  ▅▇    █                                                        
  ██▄▂▂▄█▇▃▂▂▄▆▅▂▂▂▅▄▃▂▂▃▂▃▂▂▂▁▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  276 μs           Histogram: frequency by time          360 μs <

 Memory estimate: 14.06 KiB, allocs estimate: 290.
```
 #### new version
 ```julia_repl
julia> @benchmark NMEAParser.hash_msg(message)
BenchmarkTools.Trial: 10000 samples with 651 evaluations.
 Range (min … max):  188.210 ns … 320.198 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     188.425 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   196.120 ns ±  14.939 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █    ▆    ▁ ▁▂▁          ▁▂▂▂  ▂ ▁▁                   ▁▁      ▁
  █▆▆▄▆█▆▄▅▆█▆███████▇▆▆▄▆▄███████████▆▇▆▆███▇▇▆▆▅▆▅▁▄▇███▇▆▆▇▅ █
  188 ns        Histogram: log(frequency) by time        250 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
 
julia> @benchmark NMEAParser.nmea_parse(message)
BenchmarkTools.Trial: 10000 samples with 8 evaluations.
 Range (min … max):  3.911 μs … 256.883 μs  ┊ GC (min … max): 0.00% … 94.44%
 Time  (median):     4.138 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   4.494 μs ±   3.500 μs  ┊ GC (mean ± σ):  1.03% ±  1.33%

   ▅█▅▅                                                        
  ▂████▆▂▁▁▁▁▁▁▃▃▃▄▃▃▂▃▃▃▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  3.91 μs         Histogram: frequency by time        7.01 μs <

 Memory estimate: 1.59 KiB, allocs estimate: 9.
 ```
 
For all the benchmarks `message = raw"$GPGGA,135020.000,5540.2676,N,01231.2830,E,2,10,0.8,24.7,M,41.5,M,3.8,0000"`
 is used as the test data.